### PR TITLE
scaffold: CMake monorepo + pybind11; minimal forge_core; Python package aegis; CTest integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.21)
+project(AEGIS LANGUAGES CXX)
+
+option(AEGIS_ENABLE_CUDA  "Enable CUDA if available" ON)
+option(AEGIS_BUILD_PYTHON "Build Python bindings"    ON)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Try to enable CUDA if available (no hard fail)
+if (AEGIS_ENABLE_CUDA)
+  include(CheckLanguage)
+  check_language(CUDA)
+  if (CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+    add_compile_definitions(AEGIS_HAVE_CUDA=1)
+  endif ()
+endif ()
+
+# Where we’ll place built Python artifacts
+set(AEGIS_PY_OUT ${CMAKE_BINARY_DIR}/python/aegis)
+
+# Fetch pybind11 if we’re building Python bindings
+if (AEGIS_BUILD_PYTHON)
+  include(FetchContent)
+  FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG v2.12.0
+  )
+  FetchContent_MakeAvailable(pybind11)
+endif ()
+
+# Modules
+add_subdirectory(forge)
+add_subdirectory(alpha_foundry)
+add_subdirectory(hedge_smith)
+add_subdirectory(orca)
+
+include(CTest)
+enable_testing()
+
+if (BUILD_TESTING AND AEGIS_BUILD_PYTHON)
+  # We only need a Python interpreter
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+  # Run python with both build/python and python on sys.path
+  add_test(
+    NAME python_import_hello
+    COMMAND
+      ${Python3_EXECUTABLE}
+      -c
+      "import sys; sys.path[:0]=['${CMAKE_BINARY_DIR}/python','${CMAKE_SOURCE_DIR}/python']; import aegis; print(aegis.hello())"
+  )
+
+  # Pass if the output contains the expected string
+  set_tests_properties(python_import_hello
+    PROPERTIES PASS_REGULAR_EXPRESSION "hello from forge_core")
+endif ()
+

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,30 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21 },
+  "configurePresets": [
+    {
+      "name": "default-debug",
+      "displayName": "Default Debug",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "AEGIS_BUILD_PYTHON": "ON",
+        "AEGIS_ENABLE_CUDA": "ON"
+      }
+    },
+    {
+      "name": "default-release",
+      "displayName": "Default Release",
+      "binaryDir": "${sourceDir}/build-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "AEGIS_BUILD_PYTHON": "ON",
+        "AEGIS_ENABLE_CUDA": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "build-debug",   "configurePreset": "default-debug" },
+    { "name": "build-release", "configurePreset": "default-release" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
 # AEGIS
-End-to-end modular platform for Alpha → Risk → Execution, with C++/CUDA pricing core and Python bindings.
+
+**AEGIS** (Alpha • Exposure • Greeks • Infrastructure • Strategy) is a modular scaffold for a quant research + risk + execution stack.  
+This repository provides a clean **C++20 + CMake** monorepo with **pybind11** bindings and a minimal end-to-end path so you can start adding pricers, Greeks, IV surfaces, and reports without reworking the build.
+
+---
+
+## What’s here (scaffold)
+- Monorepo layout: `forge/` (core C++), `alpha_foundry/`, `hedge_smith/`, `orca/`
+- Root CMake with optional CUDA detection and pybind11 via `FetchContent`
+- Minimal C++ lib `forge_core::hello()` + Python extension `_forge`
+- Python package `aegis` that re-exports `hello()` (no binary copies in source)
+- CTest that imports the package and verifies the binding
+
+---
+
+## Build & quick test (dev)
+
+```bash
+# 1) Configure
+cmake -S . -B build -DAEGIS_BUILD_PYTHON=ON
+
+# 2) Build (C++ lib + pybind11 extension)
+cmake --build build -j
+
+# 3) Make Python see both the built extension and the source package
+export PYTHONPATH="$(pwd)/build/python:$(pwd)/python"
+
+# 4) Smoke test (should print: hello from forge_core)
+python3 -c "import aegis; print(aegis.hello())"
+
+# 5) Run the CTest suite
+cd build && ctest --output-on-failure
+
+```
+
+## Requirements
+- CMake ≥ 3.21
+- C++20 compiler (tested with AppleClang 17)
+- Python ≥ 3.8 (development headers available)
+- (Optional) CUDA toolkit — detected automatically if present
+
+``` 
+AEGIS/
+├─ forge/
+│  ├─ include/forge/forge.h         # public header
+│  ├─ src/forge.cpp                 # minimal core impl
+│  └─ python_bindings/forge_py.cpp  # pybind11 module (_forge)
+├─ alpha_foundry/                   # stub target (research)
+│  └─ CMakeLists.txt
+├─ hedge_smith/                     # stub target (risk/hedging)
+│  └─ CMakeLists.txt
+├─ orca/                            # stub target (execution)
+│  └─ CMakeLists.txt
+├─ python/aegis/__init__.py         # Python package (namespace + wrapper)
+├─ CMakeLists.txt                   # root build
+├─ CMakePresets.json                # debug/release presets
+└─ README.md
+
+```
+## Design notes
+- Build artifacts stay out of the source tree.
+    The Python package uses a namespace-like pattern so aegis._forge lives in build/python/aegis/.
+- Monorepo, module-first: each top-level folder owns its targets and bindings.
+- Reproducible and CI-ready: single CMake entry point + CTest smoke test.
+
+## License
+Apache-2.0

--- a/alpha_foundry/CMakeLists.txt
+++ b/alpha_foundry/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(alpha_foundry_core INTERFACE)

--- a/forge/CMakeLists.txt
+++ b/forge/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(forge_core STATIC
+  src/forge.cpp
+)
+target_include_directories(forge_core PUBLIC include)
+
+if (AEGIS_BUILD_PYTHON)
+  pybind11_add_module(forge_py
+    python_bindings/forge_py.cpp
+  )
+  target_link_libraries(forge_py PRIVATE forge_core)
+  set_target_properties(forge_py PROPERTIES OUTPUT_NAME "_forge")
+  set_target_properties(forge_py PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${AEGIS_PY_OUT}
+  )
+endif ()

--- a/forge/include/forge/forge.h
+++ b/forge/include/forge/forge.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <string>
+
+namespace forge {
+    std::string hello();
+}

--- a/forge/python_bindings/forge_py.cpp
+++ b/forge/python_bindings/forge_py.cpp
@@ -1,0 +1,10 @@
+#include "forge/forge.h"
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+// Builds a Python extension module named "_forge"
+PYBIND11_MODULE(_forge, m) {
+  m.doc() = "AEGIS forge Python bindings (minimal)";
+  m.def("hello_core", &forge::hello, "Return string from C++ forge_core");
+}

--- a/forge/src/forge.cpp
+++ b/forge/src/forge.cpp
@@ -1,0 +1,5 @@
+#include "forge/forge.h"
+
+namespace forge {
+  std::string hello() { return "hello from forge_core"; }
+}

--- a/hedge_smith/CMakeLists.txt
+++ b/hedge_smith/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(hedge_smith_core INTERFACE)

--- a/orca/CMakeLists.txt
+++ b/orca/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(orca_core INTERFACE)

--- a/python/aegis/__init__.py
+++ b/python/aegis/__init__.py
@@ -1,0 +1,38 @@
+"""
+AEGIS dev package.
+
+During development, the native extension (_forge) is built into:
+  build/python/aegis/_forge*.so
+
+We make the 'aegis' package span BOTH the source tree (python/aegis)
+and the build tree (build/python/aegis) by using pkgutil.extend_path.
+This keeps binaries out of the source repo and gives clean imports.
+
+Usage after building:
+  export PYTHONPATH="$(pwd)/build/python:$(pwd)/python"
+  python3 -c "import aegis; print(aegis.hello())"  # -> "hello from forge_core"
+"""
+from __future__ import annotations
+
+from pkgutil import extend_path
+
+# Make 'aegis' behave like a namespace package across multiple dirs on sys.path.
+# This lets Python see aegis/_forge in build/python/aegis alongside this file.
+__path__ = extend_path(__path__, __name__)  # type: ignore[name-defined]
+
+# Friendly Python API that calls into the C++ core via pybind11.
+try:
+    # Re-export as aegis.hello()
+    from ._forge import hello_core as hello  # type: ignore[attr-defined]
+except Exception as e:
+    # Helpful error if the extension isn't built or not on PYTHONPATH
+    def hello() -> str:
+        raise RuntimeError(
+            "aegis._forge not found.\n"
+            "Build the project and ensure PYTHONPATH includes BOTH:\n"
+            "  - $(repo)/build/python\n"
+            "  - $(repo)/python\n"
+            "Example:\n"
+            '  export PYTHONPATH="$(pwd)/build/python:$(pwd)/python"\n'
+            "Then: python3 -c \"import aegis; print(aegis.hello())\""
+        ) from e


### PR DESCRIPTION
### Summary
Initial scaffold for the AEGIS monorepo with CMake, C++20, pybind11 bindings, and a minimal Python package.

### Details
- Root CMake with optional CUDA detection and pybind11 via FetchContent
- Minimal C++ library `forge_core::hello()` + pybind11 extension `_forge`
- Python package `aegis` (namespace path, no binary copies)
- CTest smoke test: imports aegis and checks `hello()` output
- Added CMakePresets.json for debug/release
- Added README with build + test instructions
- Added .gitignore for local artifacts

### Related issues
Closes #1
